### PR TITLE
Hide local-only pinned toots from public profiles

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -27,7 +27,7 @@ class AccountsController < ApplicationController
           return
         end
 
-        @pinned_statuses = cache_collection(@account.pinned_statuses, Status) if show_pinned_statuses?
+        @pinned_statuses = cache_collection(@account.pinned_statuses.not_local_only, Status) if show_pinned_statuses?
         @statuses        = filtered_status_page
         @statuses        = cache_collection(@statuses, Status)
         @rss_url         = rss_url

--- a/app/controllers/activitypub/collections_controller.rb
+++ b/app/controllers/activitypub/collections_controller.rb
@@ -24,7 +24,7 @@ class ActivityPub::CollectionsController < ActivityPub::BaseController
   def set_size
     case params[:id]
     when 'featured'
-      @size = @account.pinned_statuses.count
+      @size = @account.pinned_statuses.not_local_only.count
     else
       not_found
     end
@@ -39,7 +39,7 @@ class ActivityPub::CollectionsController < ActivityPub::BaseController
       if authorized_fetch_mode? && !signed_request_account.nil? && (@account.blocking?(signed_request_account) || (!signed_request_account.domain.nil? && @account.domain_blocking?(signed_request_account.domain)))
         Status.none
       else
-        @account.pinned_statuses
+        @account.pinned_statuses.not_local_only
       end
     end
   end


### PR DESCRIPTION
Fixes #1336

This also fixes federating pinned toots when some of them are local-only.

Public profiles will not show public toots, whether you are logged in
or not (this is consistent with local-only toots that are not pinned).